### PR TITLE
Improve hygiene of syms! macro

### DIFF
--- a/glsp-engine/src/engine.rs
+++ b/glsp-engine/src/engine.rs
@@ -787,12 +787,12 @@ macro_rules! syms {
 		}
 	) => (
 		$struct_vis struct $struct_name {
-			$($vis $name: Sym,)*
+			$($vis $name: crate::Sym,)*
 		}
 
 		impl $struct_name {
 			#[allow(unused_variables)]
-			$struct_vis fn new() -> GResult<Syms> {
+			$struct_vis fn new() -> crate::GResult<Self> {
 				Ok($struct_name {
 					$($name: glsp::sym($contents)?,)*
 				})


### PR DESCRIPTION
Previously, the macro relied on having `glsp::{GResult, Sym}` in scope and would return a struct named `Syms` regardless of the `$struct_name`